### PR TITLE
Handle Projectcompatversion record

### DIFF
--- a/VbProjectParser/Data/_PROJECTINFORMATION/PROJECTCOMPATVERSION.cs
+++ b/VbProjectParser/Data/_PROJECTINFORMATION/PROJECTCOMPATVERSION.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using VbProjectParser.Compression;
+using VbProjectParser.Data.Exceptions;
+
+namespace VbProjectParser.Data._PROJECTINFORMATION
+{
+    public class PROJECTCOMPATVERSION : DataBase
+    {
+        public static UInt16 RecordId = 0x004A;
+
+        [MustBe((UInt16)0x004A)]
+        public readonly UInt16 Id;
+
+        [MustBe((UInt32)0x00000004)]
+        public readonly UInt32 Size;
+
+        public readonly UInt32 CompatVersion;
+
+        public PROJECTCOMPATVERSION(XlBinaryReader Data)
+        {
+            this.Id = Data.ReadUInt16();
+            this.Size = Data.ReadUInt32();
+            this.CompatVersion = Data.ReadUInt32();
+
+            Validate();
+        }
+    }
+}

--- a/VbProjectParser/Data/_PROJECTINFORMATION/_PROJECTINFORMATION.cs
+++ b/VbProjectParser/Data/_PROJECTINFORMATION/_PROJECTINFORMATION.cs
@@ -13,6 +13,7 @@ namespace VbProjectParser.Data._PROJECTINFORMATION
     public class PROJECTINFORMATION : DataBase
     {
         public readonly PROJECTSYSKIND SysKindRecord;
+        public readonly PROJECTCOMPATVERSION ProjectCompatVersion;
         public readonly PROJECTLCID LcidRecord;
         public readonly PROJECTLCIDINVOKE LcidInvokeRecord;
         public readonly PROJECTCODEPAGE CodePageRecord;
@@ -27,6 +28,15 @@ namespace VbProjectParser.Data._PROJECTINFORMATION
         public PROJECTINFORMATION(XlBinaryReader Data)
         {
             this.SysKindRecord = new PROJECTSYSKIND(Data);
+
+            // Excel 2019 includes a new PROJECTCOMPATVERSION Record (section 2.3.4.2.1.2).
+            // Check if the project has a PROJECTCOMPATVERSION record.
+            int nextRecordType = Data.PeekUInt16();
+            if (nextRecordType == PROJECTCOMPATVERSION.RecordId)
+            {
+                this.ProjectCompatVersion = new PROJECTCOMPATVERSION(Data);
+            }
+
             this.LcidRecord = new PROJECTLCID(Data);
             this.LcidInvokeRecord = new PROJECTLCIDINVOKE(Data);
             this.CodePageRecord = new PROJECTCODEPAGE(Data);

--- a/VbProjectParser/VbProjectParser.csproj
+++ b/VbProjectParser/VbProjectParser.csproj
@@ -101,6 +101,7 @@
     <Compile Include="Data\ABNF\ProjectWindow.cs" />
     <Compile Include="Data\ABNF\ProjectWindowState.cs" />
     <Compile Include="Data\_PROJECTINFORMATION\PROJECTCODEPAGE.cs" />
+    <Compile Include="Data\_PROJECTINFORMATION\PROJECTCOMPATVERSION.cs" />
     <Compile Include="Data\_PROJECTINFORMATION\PROJECTCONSTANTS.cs" />
     <Compile Include="Data\_PROJECTINFORMATION\PROJECTDOCSTRING.cs" />
     <Compile Include="Data\_PROJECTINFORMATION\PROJECTHELPCONTEXT.cs" />

--- a/VbProjectParser/VbProjectParser.csproj
+++ b/VbProjectParser/VbProjectParser.csproj
@@ -37,8 +37,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-    <Reference Include="OpenMcdf">
-      <HintPath>..\packages\OpenMcdf.2.0.5739.40493\lib\OpenMcdf.dll</HintPath>
+    <Reference Include="OpenMcdf, Version=2.3.1.0, Culture=neutral, PublicKeyToken=fdbb1629d7c00800, processorArchitecture=MSIL">
+      <HintPath>..\packages\OpenMcdf.2.3.1\lib\net40\OpenMcdf.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -140,9 +140,6 @@
     <Compile Include="Data\VbaStorage.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <ItemGroup>
@@ -150,6 +147,9 @@
       <Project>{f0a82007-ae94-46e2-b836-716b26802a5f}</Project>
       <Name>AbnfFramework</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/VbProjectParser/packages.config
+++ b/VbProjectParser/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="OpenMcdf" version="2.0.5739.40493" targetFramework="net45" />
+  <package id="OpenMcdf" version="2.3.1" targetFramework="net48" />
 </packages>

--- a/VbProjectParserOpenXmlIntegration/VbProjectParserOpenXmlIntegration.csproj
+++ b/VbProjectParserOpenXmlIntegration/VbProjectParserOpenXmlIntegration.csproj
@@ -31,12 +31,14 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DocumentFormat.OpenXml, Version=2.5.5631.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <Private>True</Private>
-      <HintPath>..\packages\DocumentFormat.OpenXml.2.5\lib\DocumentFormat.OpenXml.dll</HintPath>
+    <Reference Include="DocumentFormat.OpenXml, Version=3.0.2.0, Culture=neutral, PublicKeyToken=8fb06cb64d019a17, processorArchitecture=MSIL">
+      <HintPath>..\packages\DocumentFormat.OpenXml.3.0.2\lib\net46\DocumentFormat.OpenXml.dll</HintPath>
     </Reference>
-    <Reference Include="OpenMcdf">
-      <HintPath>..\packages\OpenMcdf.2.0.5739.40493\lib\OpenMcdf.dll</HintPath>
+    <Reference Include="DocumentFormat.OpenXml.Framework, Version=3.0.2.0, Culture=neutral, PublicKeyToken=8fb06cb64d019a17, processorArchitecture=MSIL">
+      <HintPath>..\packages\DocumentFormat.OpenXml.Framework.3.0.2\lib\net46\DocumentFormat.OpenXml.Framework.dll</HintPath>
+    </Reference>
+    <Reference Include="OpenMcdf, Version=2.3.1.0, Culture=neutral, PublicKeyToken=fdbb1629d7c00800, processorArchitecture=MSIL">
+      <HintPath>..\packages\OpenMcdf.2.3.1\lib\net40\OpenMcdf.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -54,13 +56,13 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\VbProjectParser\VbProjectParser.csproj">
       <Project>{3b584d6d-0292-4966-9426-da02bf1efaac}</Project>
       <Name>VbProjectParser</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/VbProjectParserOpenXmlIntegration/packages.config
+++ b/VbProjectParserOpenXmlIntegration/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DocumentFormat.OpenXml" version="2.5" targetFramework="net451" />
-  <package id="OpenMcdf" version="2.0.5739.40493" targetFramework="net451" />
+  <package id="DocumentFormat.OpenXml" version="3.0.2" targetFramework="net48" />
+  <package id="DocumentFormat.OpenXml.Framework" version="3.0.2" targetFramework="net48" />
+  <package id="OpenMcdf" version="2.3.1" targetFramework="net48" />
 </packages>

--- a/VbProjectParserUsage/VbProjectParserUsage.csproj
+++ b/VbProjectParserUsage/VbProjectParserUsage.csproj
@@ -34,12 +34,14 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DocumentFormat.OpenXml, Version=2.5.5631.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <Private>True</Private>
-      <HintPath>..\packages\DocumentFormat.OpenXml.2.5\lib\DocumentFormat.OpenXml.dll</HintPath>
+    <Reference Include="DocumentFormat.OpenXml, Version=3.0.2.0, Culture=neutral, PublicKeyToken=8fb06cb64d019a17, processorArchitecture=MSIL">
+      <HintPath>..\packages\DocumentFormat.OpenXml.3.0.2\lib\net46\DocumentFormat.OpenXml.dll</HintPath>
     </Reference>
-    <Reference Include="OpenMcdf">
-      <HintPath>..\packages\OpenMcdf.2.0.5739.40493\lib\OpenMcdf.dll</HintPath>
+    <Reference Include="DocumentFormat.OpenXml.Framework, Version=3.0.2.0, Culture=neutral, PublicKeyToken=8fb06cb64d019a17, processorArchitecture=MSIL">
+      <HintPath>..\packages\DocumentFormat.OpenXml.Framework.3.0.2\lib\net46\DocumentFormat.OpenXml.Framework.dll</HintPath>
+    </Reference>
+    <Reference Include="OpenMcdf, Version=2.3.1.0, Culture=neutral, PublicKeyToken=fdbb1629d7c00800, processorArchitecture=MSIL">
+      <HintPath>..\packages\OpenMcdf.2.3.1\lib\net40\OpenMcdf.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/VbProjectParserUsage/packages.config
+++ b/VbProjectParserUsage/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DocumentFormat.OpenXml" version="2.5" targetFramework="net451" />
-  <package id="OpenMcdf" version="2.0.5739.40493" targetFramework="net451" />
+  <package id="DocumentFormat.OpenXml" version="3.0.2" targetFramework="net48" />
+  <package id="DocumentFormat.OpenXml.Framework" version="3.0.2" targetFramework="net48" />
+  <package id="OpenMcdf" version="2.3.1" targetFramework="net48" />
 </packages>


### PR DESCRIPTION
Adding support for newer VBA ProjectCompatVersionRecord.

Doing a minimal fix here by adding a check if the VBA being read in contains the ProjectCompatVersionRecord and reads in the data if found. 

This pull request contains both the fixes for the ProjectCompatVersionRecord and the Nuget Package upgrades in https://github.com/fabianoliver/VbProjectParser/pull/5. If https://github.com/fabianoliver/VbProjectParser/pull/5 is picked up I can republish this pull request with just the ProjectCompatVersionRecord changes.

