### PR TITLE
Crash if CompressionContainer contains more than one CompressedChunk #7

### DIFF
--- a/VbProjectParser/Compression/CompressedChunkData.cs
+++ b/VbProjectParser/Compression/CompressedChunkData.cs
@@ -41,8 +41,9 @@ namespace VbProjectParser.Compression
                 // TODO: DO something like when compressedcurrent < compressedend -> add a new tokensequence
 
                 // page 57: CompressedChunkData contains an array of TokenSequence elements
-
-                var size = Math.Min(header.CompressedChunkSize, Data.Length - Data.i);
+                // Subtract 2 from the header.CompressedChunkSize since have already read 
+                // two bytes from the CompressedChunk data when the header was read.
+                var size = Math.Min(header.CompressedChunkSize - 2, Data.Length - Data.i);
                 var tokenSequences = new List<TokenSequence>();
 
                 int processedBytes = 0;


### PR DESCRIPTION
When a file is read with multiple CompressedChunks an exception will occur:
System.FormatException: 'Signature byte expected 0x03, 

This is caused by the size of data to be read from the CompressedChunk the CompressionContainer is incorrect.
From: CompressedChunkData.cs, line#47
var size = Math.Min(header.CompressedChunkSize, Data.Length - Data.i);

The header.CompressedChunkSize is being used as the remaining bytes to be read in from the stream. Since the first two bytes have already been read from the chunk the proper calculation is:
var size = Math.Min(header.CompressedChunkSize -2, Data.Length - Data.i);

MSFT documents how to read the chunk at:
https://learn.microsoft.com/en-us/openspecs/office_file_formats/ms-ovba/3d5ea4df-e8a5-4079-a454-9595b840525f

This is also tracked by https://github.com/fabianoliver/VbProjectParser/issues/7