### PR TITLE
Add support for REFERENCEORIGINAL record

### DIFF
--- a/VbProjectParser/Data/_PROJECTREFERENCES/Reference.cs
+++ b/VbProjectParser/Data/_PROJECTREFERENCES/Reference.cs
@@ -13,6 +13,7 @@ namespace VbProjectParser.Data._PROJECTREFERENCES
     public class REFERENCE : DataBase
     {
         public readonly REFERENCENAME NameRecord;
+        public readonly REFERENCEORIGINAL ReferenceOriginalRecord;
         public readonly object ReferenceRecord;
 
         public REFERENCE(PROJECTINFORMATION ProjectInformation, XlBinaryReader Data)
@@ -27,8 +28,10 @@ namespace VbProjectParser.Data._PROJECTREFERENCES
             }
             else if (peek == 0x0033)
             {
-                // todo: Test this, documentation says 0x0033 is REFERENCECONTROL too but this seems odd
-                this.ReferenceRecord = new REFERENCEORIGINAL(Data);
+                this.ReferenceOriginalRecord = new REFERENCEORIGINAL(Data);
+
+                // A reference original is followed immediately by a reference record.
+                this.ReferenceRecord = new REFERENCECONTROL(ProjectInformation, Data);
             }
             else if (peek == 0x000D)
             {

--- a/VbProjectParser/Data/_PROJECTREFERENCES/ReferenceRecords/REFERENCEORIGINAL.cs
+++ b/VbProjectParser/Data/_PROJECTREFERENCES/ReferenceRecords/REFERENCEORIGINAL.cs
@@ -7,10 +7,9 @@ using VbProjectParser.Compression;
 
 namespace VbProjectParser.Data._PROJECTREFERENCES.ReferenceRecords
 {
-    // todo
     public class REFERENCEORIGINAL : DataBase
     {
-        [MustBe((UInt16)0x000E)]
+        [MustBe((UInt16)0x0033)]
         public readonly UInt16 Id;
 
         public readonly UInt32 SizeOfLibidOriginal;


### PR DESCRIPTION
Issue: https://github.com/fabianoliver/VbProjectParser/issues/9

If the project contains a REFERENCEORIGINAL record VBAParser will crash on load.

This is because the as part of the REFERENCEORIGINAL record persisted it also has REFERENCECONTROL data as part of the record that immediately follows the REFERENCEORIGINAL data that currently isn't being read.

Updated code to immediately read the REFERENCECONTROL record after reading the REFERENCEORIGINAL record.

documented at:
https://learn.microsoft.com/en-us/openspecs/office_file_formats/ms-ovba/3ba66994-8c7a-4634-b2da-f9331ace6686