### PR TITLE
Handle multiple [Host Extender] Info entries

### DIFF
--- a/VbProjectParser/Data/ABNF/HostExtenderRef.cs
+++ b/VbProjectParser/Data/ABNF/HostExtenderRef.cs
@@ -53,7 +53,7 @@ namespace VbProjectParser.Data.ABNF
             Syntax
                 .Entity<HostExtenderRef>()
                 .Property(x => x.LibName)
-                .ByRegexPattern("VBE[\x21-\x3A\x3C-\xFF]*")
+                .ByRegexPattern("VBE|[\x21-\x3A\x3C-\xFF]*")
                 .WithPostfix(new LiteralToken(";"));
 
             Syntax

--- a/VbProjectParser/Data/ABNF/HostExtenders.cs
+++ b/VbProjectParser/Data/ABNF/HostExtenders.cs
@@ -23,8 +23,7 @@ namespace VbProjectParser.Data.ABNF
             Syntax
                 .Entity<HostExtenders>()
                 .EnumerableProperty(x => x.HostExtenderRef)
-                .ByRegisteredTypes(typeof(HostExtenderRef))
-                .WithPrefix(new LiteralToken("[Host Extender Info]") + CommonTokens.NWLN);
+                .ByRegisteredTypes(typeof(HostExtenderRef));
         }
     }
 }

--- a/VbProjectParser/Data/ABNF/VBAPROJECTText.cs
+++ b/VbProjectParser/Data/ABNF/VBAPROJECTText.cs
@@ -27,13 +27,15 @@ namespace VbProjectParser.Data.ABNF
             Syntax
                 .Entity<VBAPROJECTText>()
                 .Property(x => x.HostExtenders)
-                .ByRegisteredTypes(typeof(HostExtenders));
+                .ByRegisteredTypes(typeof(HostExtenders))
+                .WithPrefix(new LiteralToken("[Host Extender Info]") + CommonTokens.NWLN)
+                .WithPostfix(CommonTokens.NWLN);
 
             Syntax
                 .Entity<VBAPROJECTText>()
                 .Property(x => x.ProjectWorkspace)
                 .ByRegisteredTypes(typeof(ProjectWorkspace))
-                .WithPrefix(CommonTokens.NWLN + new LiteralToken("[Workspace]") + CommonTokens.NWLN)
+                .WithPrefix(new LiteralToken("[Workspace]") + CommonTokens.NWLN)
                 .IsOptional();
         }
     }


### PR DESCRIPTION
Proposed fix for https://github.com/fabianoliver/VbProjectParser/issues/8.

Issue:
An InvalidOperationException will occur when parsing a ProjectStream contains more than one [Host Extender Info] or if the entry libname does not start with VBE.

Example of [HostExtenderInfo] that will reproduce both issues:

[Host Extender Info]
&H00000001={3832D640-CF90-11CF-8E43-00A0C911005A};VBE;&H00000000
&H00000002={00020818-0000-0000-C000-000000000046};Excel8.0;&H00000000

Fix:
The fixes are to the following files.

HostExtenderRef.cs - The RegEx expression for matching the LibName as written requires the Library to begin with VBE This fails when a library name has a name such as Excel8.0. The ABNF documentations states that instead of the VBE being a required prefix its the syntax "VBE" / *(%x21-3A / %x3C-FF). The / indicates this should be an | so updating RegEx to be "VBE|[\x21-\x3A\x3C-\xFF]*". Note: The VBE is somewhat redundant since its covered by the ascii codes but documentation indicates VBE is special and keeps the RegEx a match to documentation.  https://learn.microsoft.com/en-us/openspecs/office_file_formats/ms-ovba/9b5165d1-c585-425c-8d55-605d11bdbca0

HostExtenders.cs - any entry but the first HostExtenderInfo won't match because the HostExtender is requiring a prefix of WithPrefix(new LiteralToken("[Host Extender Info]"). Removing the WithPrefix line and address in the VBAPROJECTText.cs file.

VBAPROJECTText.cs - adding the WithPrefix(new LiteralToken("[Host Extender Info]") to the HostExtenders to mark beginning of the HostExtenders which matches the pattern for [Workspace]. Also updating to put the WithPostfix(CommonTokens.NWLN) on HostExtenders and therefore removing the leading CommonTokens.NWLN on the Workspace. This make a consistent pattern for all the toplevel entries.
