### PR TITLE
Remove check that referenced project matches the current project version

### DIFF
--- a/VbProjectParser/Data/_PROJECTREFERENCES/ReferenceRecords/REFERENCEPROJECT.cs
+++ b/VbProjectParser/Data/_PROJECTREFERENCES/ReferenceRecords/REFERENCEPROJECT.cs
@@ -27,10 +27,8 @@ namespace VbProjectParser.Data._PROJECTREFERENCES.ReferenceRecords
         [LengthMustEqualMember("SizeOfLibidRelative")]
         public readonly Byte[] LibidRelative;
 
-        [ValueMustEqualMember("ProjectInformation.VersionRecord.VersionMajor")]
         public readonly UInt32 MajorVersion;
 
-        [ValueMustEqualMember("ProjectInformation.VersionRecord.VersionMinor")]
         public readonly UInt16 MinorVersion;
 
         protected readonly PROJECTINFORMATION ProjectInformation; 


### PR DESCRIPTION
Proposed fix for https://github.com/fabianoliver/VbProjectParser/issues/13

The REFERENCEPROJECT validates that the version of the referenced project matches the current project version with the code.

REFERENCEPROJECT.cs
[ValueMustEqualMember("ProjectInformation.VersionRecord.VersionMajor")]
public readonly UInt32 MajorVersion;

    [ValueMustEqualMember("ProjectInformation.VersionRecord.VersionMinor")]
    public readonly UInt16 MinorVersion;
The referenced project is not required to have the same MajorVersion and MinorVersion and the code results in a validation error.

The fix removes the ValueMustEqualMember from the MajorVersion and MinorVersion properties.